### PR TITLE
fix: move iconcircle div above close button, close button now clickable (#4)

### DIFF
--- a/src/map/Popups/PopupItem.tsx
+++ b/src/map/Popups/PopupItem.tsx
@@ -34,6 +34,9 @@ const PopupItem = ({ place, handleBackToCluster }: PopupItemProps) => {
       offset={[0, -AppConfig.ui.markerIconSize] as never}
     >
       <div className="bg-mapBg text-dark shadow-md rounded-md p-2 -mt-3 relative">
+        <div className="flex justify-center absolute w-full left-0 top-0 mt-4">
+          <IconCircle path={`/${currentCat.iconMedium}`} size={markerSize} invert />
+        </div>
         <Button
           className="absolute right-0 top-2 text-dark inline-block"
           onClick={() => setMarkerPopup(undefined)}
@@ -41,9 +44,6 @@ const PopupItem = ({ place, handleBackToCluster }: PopupItemProps) => {
         >
           <X size={AppConfig.ui.mapIconSizeSmall} />
         </Button>
-        <div className="flex justify-center absolute w-full left-0 top-0 mt-4">
-          <IconCircle path={`/${currentCat.iconMedium}`} size={markerSize} invert />
-        </div>
         <div className="flex flex-row justify-center pt-3">
           <div
             className="flex flex-col justify-center p-3 text-center w-full"


### PR DESCRIPTION
fixes #4 

Thanks for this nice starter template!

While experimenting with some of my own data, I think I fixed an issue where the close button wasn't clickable. 

Moved the IconCircle div above the close button div in the HTML structure to prevent overlap. This change resolves the issue where the IconCircle div was covering the close button div, ensuring both elements are now fully visible and functional.

https://github.com/richard-unterberg/maplibre-nextjs-ts-starter/assets/24685932/9ef26ca4-4bb8-4ed2-8aa5-222f4ebf7fe2

